### PR TITLE
add pretty scroll bars

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,4 +1,17 @@
 .editor {
+  ::-webkit-scrollbar {
+    width: 0.5em;
+    height: 0.5em;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: #272822;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: lighten(#272822, 10%);
+  }
+  
   .wrap-guide {
     background: rgba(255, 255, 255, 0.1);
   }


### PR DESCRIPTION
Style the ugly default webkit scrollers in the editor pane. width/height is based on `em` so that the font size decides the dimensions. Maybe others like it a little thicker but I thought 0.5 was a good place to start.
