### PR TITLE
Change the GitGutter color to make it clearer

### DIFF
--- a/index.less
+++ b/index.less
@@ -10,6 +10,23 @@
   &, .gutter {
     background-color: #282828;
     color: #F8F8F2;
+
+    .line-number {
+      opacity: 1;
+      color: #93938f;
+
+      &.git-line-added {
+        border-left: 2px solid #529b2f;
+      }
+
+      &.git-line-modified {
+        border-left: 2px solid #ffd569;
+      }
+
+      &.git-line-removed {
+        border-left: 2px solid #945051;
+      }
+    }
   }
 
   &.is-focused .cursor {
@@ -121,7 +138,7 @@
     color: #F8F8F0;
     background-color: #AE81FF;
   }
-  
+
   // Jade syntax
   .class.jade {
     color: #AE81FF;


### PR DESCRIPTION
I found hard to see the changes I did in the GitGutter cause the opacity and the colors, so I did some changes to it.
## Before:

![before](https://f.cloud.github.com/assets/1068973/2461984/81c36440-af7c-11e3-959e-c077464245c9.png)
## After:

![after](https://f.cloud.github.com/assets/1068973/2461985/841127a0-af7c-11e3-8a65-1ea20089c6e9.png)
