### PR TITLE
Removed the unnecessary gutter color which invalidates other colors, such as atom-jshint-error (added by atom-jshint package).

### DIFF
--- a/index.less
+++ b/index.less
@@ -8,10 +8,10 @@
   }
 
   &, .gutter {
-    .line-number {
-      opacity: 1;
-      color: #93938f;
+    background-color: #282828;
+    color: #F8F8F2;
 
+    .line-number {
       &.git-line-added {
         border-left: 2px solid #529b2f;
       }


### PR DESCRIPTION
When atom-jshint detects there is an error in a .js file, it makes the line number red. However it does not work in the existing monokai theme. This unnecessary gutter colour invalidates other colours.
