### PR TITLE
Fixes warning on Atom 0.174.0 regarding deprecated selectors

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,11 +1,11 @@
 @import 'syntax-variables';
 
-.editor-colors, :host {
+.atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor, :host {
+.atom-text-editor, :host {
   .invisible-character {
     color: @syntax-invisible-character-color;
   }


### PR DESCRIPTION
Fixes a warning on Atom 0.174.0

# Deprecated selectors

```
index.less
Use the `atom-text-editor` tag instead of the `editor-colors` class.
Use the `atom-text-editor` tag instead of the `editor` class.
```