### PR TITLE
Remove underline from class definitions

### DIFF
--- a/index.less
+++ b/index.less
@@ -124,13 +124,13 @@ atom-text-editor, :host {
 }
 
 .entity.name.class {
-  text-decoration: underline;
+  text-decoration: none;
   color: #A6E22E;
 }
 
 .entity.other.inherited-class {
   font-style: italic;
-  text-decoration: underline;
+  text-decoration: none;
   color: #A6E22E;
 }
 


### PR DESCRIPTION
Most of people switch from Sublime Text, and its a pain to see class names with underlines.