### PR TITLE
Make text selections only show the select in the text area

### DIFF
--- a/index.less
+++ b/index.less
@@ -18,10 +18,6 @@ atom-text-editor, :host {
 
   .gutter {
     background-color: @syntax-gutter-background-color;
-
-    .cursor-line {
-      background-color: @syntax-gutter-background-color-selected;
-    }
   }
 
   .line-number.cursor-line-no-selection {


### PR DESCRIPTION
Currently it also selects the gutter which seems a little weird and uncommon.

Before:
![image](https://cloud.githubusercontent.com/assets/4171547/7336623/5acd9666-ec08-11e4-85a0-dee5679b30c0.png)

After:
![image](https://cloud.githubusercontent.com/assets/4171547/7336628/8418db02-ec08-11e4-946a-78276098b1c2.png)

