### PR TITLE
Refactor code to use LESS color variables

### DIFF
--- a/index.less
+++ b/index.less
@@ -52,12 +52,12 @@ atom-text-editor, :host {
   .gfm {
     .markup {
       &.heading {
-        color: #A6E22E;
+        color: @green;
         font-weight: bold;
       }
 
       &.underline {
-        color: #E6DB74;
+        color: @yellow;
         text-decoration: underline;
       }
     }
@@ -71,74 +71,74 @@ atom-text-editor, :host {
     }
 
     .raw {
-      color: #66D9EF;
+      color: @blue;
     }
 
     .variable.list {
-      color: #F92672;
+      color: @pink;
       font-weight: bold;
     }
 
     .link {
-      color: #CCC;
+      color: @light-gray;
 
       .entity {
-        color: #AE81FF;
+        color: @purple;
       }
     }
   }
 }
 
 .comment {
-  color: #75715E;
+  color: @brown;
 }
 
 .string {
-  color: #E6DB74;
+  color: @yellow;
 }
 
 .constant.numeric {
-  color: #AE81FF;
+  color: @purple;
 }
 
 .constant.language {
-  color: #AE81FF;
+  color: @purple;
 }
 
 .constant.character,
 .constant.escape,
 .constant.other {
-  color: #AE81FF;
+  color: @purple;
 }
 
 .keyword {
-  color: #F92672;
+  color: @pink;
 }
 
 .keyword.operator.bracket,
 .keyword.operator.punctuation,
  {
-  color: #FFFFFF;
+  color: @white;
 }
 
 .storage {
-  color: #F92672;
+  color: @pink;
 }
 
 .storage.type {
   font-style: italic;
-  color: #66D9EF;
+  color: @blue;
 }
 
 .entity.name.class {
   text-decoration: none;
-  color: #A6E22E;
+  color: @green;
 }
 
 .entity.other.inherited-class {
   font-style: italic;
   text-decoration: none;
-  color: #A6E22E;
+  color: @green;
 }
 
 // Prevent underlines from making their way into whitespace elements
@@ -148,60 +148,60 @@ atom-text-editor, :host {
 }
 
 .entity.name.function {
-  color: #A6E22E;
+  color: @green;
 }
 
 .entity.name.instance {
-  color: #66D9EF;
+  color: @blue;
 }
 
 .variable.parameter {
   font-style: italic;
-  color: #FD971F;
+  color: @orange;
 }
 
 .entity.name.tag {
-  color: #F92672;
+  color: @pink;
 }
 
 .entity.other.attribute-name {
-  color: #A6E22E;
+  color: @green;
 }
 
 .support.function {
-  color: #66D9EF;
+  color: @blue;
 }
 
 .support.function.decl {
-  color: #A6E22E;
+  color: @green;
 }
 
 .support.constant {
-  color: #66D9EF;
+  color: @blue;
 }
 
 .support.type,
 .support.class {
   font-style: italic;
-  color: #66D9EF;
+  color: @blue;
 }
 
 .invalid {
-  color: #F8F8F0;
-  background-color: #F92672;
+  color: @ghost-white;
+  background-color: @pink;
 }
 
 .invalid.deprecated {
-  color: #F8F8F0;
-  background-color: #AE81FF;
+  color: @ghost-white;
+  background-color: @purple;
 }
 
 // Jade syntax
 .class.jade {
-  color: #AE81FF;
+  color: @purple;
 }
 
 // 'this' Javascript
 .variable.language.js {
-  color: #F92672;
+  color: @pink;
 }

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,0 +1,17 @@
+@white: #FFFFFF;
+@ghost-white: #F8F8F0;
+@light-ghost-white: #F8F8F2;
+@light-gray: #CCC;
+@gray: #888;
+@brown-gray: #49483E;
+@dark-gray: #282828;
+
+@yellow: #E6DB74;
+@blue: #66D9EF;
+@pink: #F92672;
+@purple: #AE81FF;
+@brown: #75715E;
+@orange: #FD971F;
+@light-orange: #FFD569;
+@green: #A6E22E;
+@sea-green: #529B2F;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -1,8 +1,10 @@
+@import "colors";
+
 // General colors
-@syntax-text-color: #F8F8F2;
-@syntax-cursor-color: #F8F8F0;
-@syntax-selection-color: #49483E;
-@syntax-background-color: #282828;
+@syntax-text-color: @light-ghost-white;
+@syntax-cursor-color: @ghost-white;
+@syntax-selection-color: @brown-gray;
+@syntax-background-color: @dark-gray;
 
 // Guide colors
 @syntax-wrap-guide-color: rgba(255, 255, 255, .1);
@@ -10,7 +12,7 @@
 @syntax-invisible-character-color: rgba(197, 200, 198, .2);
 
 // For find and replace markers
-@syntax-result-marker-color: #888;
+@syntax-result-marker-color: @gray;
 @syntax-result-marker-color-selected: white;
 
 // Gutter colors
@@ -20,7 +22,7 @@
 @syntax-gutter-background-color-selected: @syntax-selection-color;
 
 // For git diff info. i.e. in the gutter
-@syntax-color-renamed: #ffd569;
-@syntax-color-added: #529b2f;
-@syntax-color-modified: #E6DB74;
-@syntax-color-removed: #F92672;
+@syntax-color-renamed: @light-orange;
+@syntax-color-added: @sea-green;
+@syntax-color-modified: @yellow;
+@syntax-color-removed: @pink;


### PR DESCRIPTION
Hey,

I am not sure why there are no color variable names. It looks great, and it's easier to maintain.
Let's discuss the names if you don't like them. Also there are some rgba colors that need a name. Let me know if you need this :)

Regards,
Radu