### PR TITLE
Add 5px space between gutter and code

### DIFF
--- a/index.less
+++ b/index.less
@@ -24,6 +24,10 @@ atom-text-editor, :host {
     }
   }
 
+  .gutter-container {
+    margin-right: @syntax-gutter-container-margin;
+  }
+
   .line-number.cursor-line-no-selection {
     background-color: @syntax-gutter-background-color-selected;
   }

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -19,6 +19,9 @@
 @syntax-gutter-background-color: lighten(@syntax-background-color, 3%);
 @syntax-gutter-background-color-selected: @syntax-selection-color;
 
+// Gutter margins
+@syntax-gutter-container-margin: 5px;
+
 // For git diff info. i.e. in the gutter
 @syntax-color-renamed: #ffd569;
 @syntax-color-added: #529b2f;


### PR DESCRIPTION
Gives the code a little room to breath so that it does not sit right against the gutter.  This is the same amount of space used in Sublime Text.
