### PR TITLE
use of original Monokai background color

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -6,6 +6,7 @@
 @gray: #888;
 @brown-gray: #49483E;
 @dark-gray: #282828;
+@sundried-clay: #272822;
 
 @yellow: #E6DB74;
 @blue: #66D9EF;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -4,7 +4,7 @@
 @syntax-text-color: @light-ghost-white;
 @syntax-cursor-color: @ghost-white;
 @syntax-selection-color: @brown-gray;
-@syntax-background-color: @dark-gray;
+@syntax-background-color: @sundried-clay;
 
 // Guide colors
 @syntax-wrap-guide-color: rgba(255, 255, 255, .1);


### PR DESCRIPTION
Until yet a dark-grey color (#282828) was used as background-color of the theme.
I changed it slightly to the **original Monokai background color** "sundried clay" (#272822) which is used by Sublime Text or Visual Studio Code's monokai themes as well.
This original color is **slightly more pleasant to our eyes** than the yet used grey.