### PR TITLE
Bug fix in colors.

### DIFF
--- a/index.less
+++ b/index.less
@@ -171,6 +171,7 @@ atom-text-editor {
 }
 
 .syntax--variable {
+  color: @orange;
   &.syntax--parameter {
     font-style: italic;
     color: @orange;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -1,7 +1,7 @@
 @import "colors";
 
 // General colors
-@syntax-text-color: @light-ghost-white;
+@syntax-text-color: @light-gray;
 @syntax-cursor-color: @ghost-white;
 @syntax-selection-color: @brown-gray;
 @syntax-background-color: @dark-gray;


### PR DESCRIPTION
Change @syntax-text-color to @light-gray (@light-ghost-white (previous color) is too bright).
Add color to syntax variable because orange color is not displayed as expected.