### PR TITLE
Fix broken highlighting for JSON tree-sitter grammar

### DIFF
--- a/index.less
+++ b/index.less
@@ -215,8 +215,13 @@ atom-text-editor {
 
 .syntax--json {
   .syntax--key {
-    .syntax--string {
-      color: #a6e22e;
+    .syntax--string,
+    &.syntax--string.syntax--quoted.syntax--double.syntax--dictionary {
+      color: @green;
     }
+  }
+  .syntax--markup.syntax--underline.syntax--link {
+    color: @blue;
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
### Description of the Change

This PR fixes the slightly-broken highlighting for JSON files when @Ben3eeE's tree-sitter JSON grammar is applied. See atom/language-json#68.

**These changes are backwards-compatible with the current first-mate JSON grammar.**

**Before:**  
![Screen Shot 2019-04-13 at 10 49 22 AM](https://user-images.githubusercontent.com/872474/56083470-50b7fe80-5dda-11e9-9335-4e2b42d47a46.png)

**After:**  
![Screen Shot 2019-04-13 at 10 49 39 AM](https://user-images.githubusercontent.com/872474/56083475-57df0c80-5dda-11e9-8961-c266617e85a3.png)

### Benefits

The highlighting for JSON files (the way Monokai highlighted them for the first-mate grammar) is restored.

### Possible Drawbacks

Perhaps some users do not like the green highlighting for key names, though I personally prefer them (and at any rate, it's nicer than having the key names colored the same as string values).

I'm also open to considerations for a different link style other than blue/underline. I don't have much of a preference either way on that.