### PR TITLE
Atom changed their layout and this causes it to collapse

### DIFF
--- a/index.less
+++ b/index.less
@@ -189,12 +189,6 @@ atom-text-editor {
   color: @purple;
 }
 
-// Prevent underlines from making their way into whitespace elements
-.leading-whitespace,
-.trailing-whitespace {
-  display: inline-block;
-}
-
 .syntax--js {
   .syntax--template {
     .syntax--element {


### PR DESCRIPTION
This fixes it, the whitespace classes are expected to be inline and inline-block makes them collapsed.